### PR TITLE
Feat scheduling sys

### DIFF
--- a/SymbIoT/lib/scheduler/scheduler.cpp
+++ b/SymbIoT/lib/scheduler/scheduler.cpp
@@ -59,16 +59,22 @@ void scheduler_process(String keyData, String valueData){
     value = constrain(value, 0, 4096);
     value = map(value, 0, 1001, 0, 500);
     
+
     // SEND TO CORRECT NODE 
 
+    // RESOLVE ADDRESS (ADDRESS SPACE IS BASE 16)
+    int board = key / 16;
+    int addr = key % 16;
+    Serial.print("Sending to");
+    Serial.print(addr);
+    Serial.print("with value");
+    Serial.println(value);
     // value = map(value, 0, 1001, 0, 4096);
     
     // Serial.println(value);
     // analogWrite(key, value);
     
-    // // RESOLVE ADDRESS
-    // int board = key / 16;
-    // int addr = key % 16;
+   
     
     // if(board == 0)
     //   light_a.setPWM(addr, 0, value);

--- a/SymbIoT/lib/scheduler/scheduler.cpp
+++ b/SymbIoT/lib/scheduler/scheduler.cpp
@@ -65,9 +65,9 @@ void scheduler_process(String keyData, String valueData){
     // RESOLVE ADDRESS (ADDRESS SPACE IS BASE 16)
     int board = key / 16;
     int addr = key % 16;
-    Serial.print("Sending to");
+    Serial.print("Sending to ");
     Serial.print(addr);
-    Serial.print("with value");
+    Serial.print("with value ");
     Serial.println(value);
     // value = map(value, 0, 1001, 0, 4096);
     

--- a/SymbIoT/lib/scheduler/scheduler.cpp
+++ b/SymbIoT/lib/scheduler/scheduler.cpp
@@ -1,0 +1,83 @@
+#include "scheduler.h"
+//Scheduling variables 
+// 12 is the maximum length of a decimal representation of a 32-bit integer,
+// including space for a leading minus sign and terminating null byte
+char scheduler_buffer[12];
+String keyData = "";
+String valueData = "";
+int delimiter = (int) '\n';
+int comma = (int) ',';
+bool key = true;
+
+
+void schedulder_parse_key_value(char* serial_buffer, size_t size) {
+    //discard the first command byte
+    for(uint8_t i = 1; i < size; i++){
+      
+      int ch = serial_buffer[i];
+
+      if(serial_buffer[i] == '\0'){
+        break;
+      }
+      else if (ch == -1) {
+        // Handle error
+      }
+      else if (ch == comma){
+        key = false;
+        break;
+      }
+      else if (ch == delimiter) {
+        key = true;
+        scheduler_process(keyData, valueData);
+        keyData = "";
+        valueData = "";
+        break;
+      }
+      else if (key){
+        keyData += (char) ch;
+      }
+      else if(!key){
+        valueData += (char) ch;
+      }
+    }
+}
+
+
+void scheduler_process(String keyData, String valueData){
+    unsigned int n = keyData.length() + 1;
+    keyData.toCharArray(scheduler_buffer, n);
+   
+    int key = atoi(scheduler_buffer);
+
+    // Convert ASCII-encoded integer to an int
+    n = valueData.length() + 1;
+    valueData.toCharArray(scheduler_buffer, n);
+    int value = atoi(scheduler_buffer);
+
+
+    // value = map(value, 0, 1000, 0, 255);
+    value = constrain(value, 0, 4096);
+    value = map(value, 0, 1001, 0, 500);
+    
+    // SEND TO CORRECT NODE 
+
+    // value = map(value, 0, 1001, 0, 4096);
+    
+    // Serial.println(value);
+    // analogWrite(key, value);
+    
+    // // RESOLVE ADDRESS
+    // int board = key / 16;
+    // int addr = key % 16;
+    
+    // if(board == 0)
+    //   light_a.setPWM(addr, 0, value);
+    // else if(board == 1)
+    //   light_b.setPWM(addr, 0, value);
+    // else if(board == 2){
+      
+    //   value = map(value, 0, 1001, 150, 525);
+    //   // light_a.setPWM(0, 0, value);
+    //   servos.setPWM(addr, 0, value);
+}
+

--- a/SymbIoT/lib/scheduler/scheduler.cpp
+++ b/SymbIoT/lib/scheduler/scheduler.cpp
@@ -69,6 +69,12 @@ void scheduler_process(String keyData, String valueData){
     Serial.print(addr);
     Serial.print("with value ");
     Serial.println(value);
+
+
+    // JASPER:
+    // NETWORK COMMAND GOES HERE
+    // send(addr, from_addr, command_syntax_i_do_not_know);
+
     // value = map(value, 0, 1001, 0, 4096);
     
     // Serial.println(value);

--- a/SymbIoT/lib/scheduler/scheduler.h
+++ b/SymbIoT/lib/scheduler/scheduler.h
@@ -1,0 +1,18 @@
+/*
+ *  Scheduling Interface - Header File
+ *  ------------------------------------
+ *  Parses a command from serial
+ *  Sends to the appropriate node at the appropriate time
+ */ 
+
+#ifndef __Expresso__scheduler__
+#define __Expresso__scheduler__
+
+#include <Arduino.h>
+#include "string.h"
+void scheduler_process(String keyData, String valueData);
+void schedulder_parse_key_value(char* serial_buffer, size_t size);
+
+#endif /* defined(__Expresso__scheduler__) */
+
+

--- a/SymbIoT/src/serial_adafruit_pwm_multi/serial_adafruit_pwm_multi.ino
+++ b/SymbIoT/src/serial_adafruit_pwm_multi/serial_adafruit_pwm_multi.ino
@@ -41,40 +41,6 @@ int delimiter = (int) '\n';
 int comma = (int) ',';
 bool key = true;
 
-void process(String keyData, String valueData){
-    unsigned int n = keyData.length() + 1;
-    keyData.toCharArray(buffer, n);
-   
-    int key = atoi(buffer);
-
-    // Convert ASCII-encoded integer to an int
-    n = valueData.length() + 1;
-    valueData.toCharArray(buffer, n);
-    int value = atoi(buffer);
-
-
-    // value = map(value, 0, 1000, 0, 255);
-    value = constrain(value, 0, 4096);
-    value = map(value, 0, 1001, 0, 500);
-    // value = map(value, 0, 1001, 0, 4096);
-    
-    // Serial.println(value);
-    // analogWrite(key, value);
-    
-    // RESOLVE ADDRESS
-    int board = key / 16;
-    int addr = key % 16;
-    if(board == 0)
-      light_a.setPWM(addr, 0, value);
-    else if(board == 1)
-      light_b.setPWM(addr, 0, value);
-    else if(board == 2){
-      
-      value = map(value, 0, 1001, 150, 525);
-      // light_a.setPWM(0, 0, value);
-      servos.setPWM(addr, 0, value);
-    }
-}
 void loop() {
     while (Serial.available()) {
         int ch = Serial.read();

--- a/SymbIoT/src/symbiot/symbiot.cpp
+++ b/SymbIoT/src/symbiot/symbiot.cpp
@@ -4,6 +4,7 @@
 #include "socket.h"
 
 #define IS_DIGIT(c) ((c >= '0' && c <= '9') ? 1 : 0)
+#define SERIAL_BUFFER_SIZE 32
 #include "printf.h"
 
 // Function prototypes
@@ -14,12 +15,35 @@ void handle_alloc_message (void);
 void handle_line_message (void);
 void actuate (void);
 uint8_t readSerialString (void);
+void welcome_message(void);
 
 uint16_t this_node;
 int received;
-char serInStr[32];
+char serInStr[SERIAL_BUFFER_SIZE];
 
 /* Main Code */
+
+void 
+welcome_message(void)
+{
+  Serial.print("Welcome! This node's id is: ");
+  Serial.println (this_node);
+  Serial.print("cmd>");
+}
+
+
+void 
+help (void)
+{
+  Serial.println("\r\nBlinkMScriptWriter!\r\n"
+   "'p' to write the script and play once\r\n"
+   "'<node address>' to send the script to a specified node\r\n"
+   "'o' to stop script playback\r\n"
+   "'x' to fade to black\r\n"
+   "'f' to flash red\r\n"
+   ); 
+}
+
 
 void setup()
 {
@@ -28,10 +52,7 @@ void setup()
   setup_radio (this_node);
   printf_begin ();
   help ();
-
-  Serial.print ("Welcome! This node's id is: ");
-  Serial.println (this_node);
-  Serial.print("cmd>");
+  welcome_message();
 }
 
 void loop()
@@ -45,6 +66,7 @@ void loop()
   if( readSerialString() ) {
     Serial.println(serInStr);
     char cmd = serInStr[0];
+
     if ( cmd == 'p' ) {
       Serial.println("Sending command on serial to blinkM...");
       BlinkM_writeScript( blinkm_addr, 0, script1_len, 0, script1_lines);
@@ -79,17 +101,6 @@ void loop()
   }
 }
 
-void
-help (void)
-{
-  Serial.println("\r\nBlinkMScriptWriter!\r\n"
-	 "'p' to write the script and play once\r\n"
-	 "'<node address>' to send the script to a specified node\r\n"
-	 "'o' to stop script playback\r\n"
-	 "'x' to fade to black\r\n"
-	 "'f' to flash red\r\n"
-   ); 
-}
 
 void
 actuate (void)
@@ -108,7 +119,12 @@ readSerialString (void)
   delay(10);  // wait a little for serial data
   int i = 0;
   while (Serial.available()) {
-    serInStr[i] = Serial.read();   // FIXME: doesn't check buffer overrun
+    if(i >= (SERIAL_BUFFER_SIZE - 1)){ //need extra byte to hold terminating 0
+      Serial.println("Serial buffer overflow!");
+      break;
+    }
+    serInStr[i] = Serial.read();   
+    // Check buffer overflow
     i++;
   }
   serInStr[i] = 0;  // indicate end of read string

--- a/SymbIoT/src/symbiot/symbiot.cpp
+++ b/SymbIoT/src/symbiot/symbiot.cpp
@@ -2,6 +2,7 @@
 #include "variables.h"
 #include "BlinkM.h"
 #include "socket.h"
+#include "scheduler.h"
 
 #define IS_DIGIT(c) ((c >= '0' && c <= '9') ? 1 : 0)
 #define SERIAL_BUFFER_SIZE 32
@@ -20,6 +21,10 @@ void welcome_message(void);
 uint16_t this_node;
 int received;
 char serInStr[SERIAL_BUFFER_SIZE];
+
+
+
+
 
 /* Main Code */
 
@@ -98,6 +103,15 @@ void loop()
         BlinkM_playScript( blinkm_addr, 0,1,0 );
         Serial.print("\r\ncmd>");
     }
+    else if(cmd =='s'){
+      //go to scheduling routine!
+      schedulder_parse_key_value(serInStr, SERIAL_BUFFER_SIZE);
+    }
+    else{
+      Serial.print("Command"); 
+      Serial.print(cmd);
+      Serial.println("received, but not understood.");
+    }
   }
 }
 
@@ -127,7 +141,7 @@ readSerialString (void)
     // Check buffer overflow
     i++;
   }
-  serInStr[i] = 0;  // indicate end of read string
+  serInStr[i] = '\0';  // indicate end of read string
   return i;  // return number of chars read
 }
 


### PR DESCRIPTION
Scheduler in place.

Send a command through serial of the form:
s{bean_id},{value}

This will cause the following message to display:
Sending to {bean_id} with value {value}.

@jhaazpr : Let us group the ids in pairs of 16, like they were on the PWM boards. That way we have backward compatibility with the PWM boards.  
e.g. Beans 0 - 15 are part of "board" 1, beans 16-31 are part of "board" 2, etc...

@jhaazpr : New task, fire the serial command and add the network send command that goes along with it. 
